### PR TITLE
Add gpt-oss-safeguard by OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Help and contribute by adding a pull request to add more resources and tools!
   * a pretrained model for detecting lewd images
 * [Sentinel by Roblox](https://github.com/Roblox/Sentinel/tree/main)
   * a Python library designed specifically for realtime detection of extremely rare classes of text by using contrastive learning principles
+* [gpt-oss-safeguard by OpenAI](https://github.com/openai/gpt-oss-safeguard)
+  * open-weight reasoning model to classify text content based on provided safety policies 
 
 ## AI-powered Guardrails
 * [Llama Guard by Meta](https://github.com/meta-llama/PurpleLlama/tree/main/Llama-Guard3)


### PR DESCRIPTION
https://github.com/openai/gpt-oss-safeguard

gpt-oss-safeguard is a set of open-weight safety reasoning models built-upon gpt-oss. With these models, you can classify text content based on safety policies that you provide and perform a suite of foundational safety tasks.

gpt-oss-safeguard was released by OpenAI in partnership with ROOST and Hugging Face after months of work, including evaluation and testing from ROOST and Discord.