### PR TITLE
Add SQRL to rules engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ Help contribute by opening a pull request to add more resources and tools!
   * high-performance rules engine for real-time event processing at scale, designed for Trust & Safety and anti-abuse work
 * [RulesEngine by Microsoft](https://microsoft.github.io/RulesEngine/)
   * library for abstracting business logic, rules, and policies from a system via JSON  for .NET language families
+* [SQRL](https://github.com/sqrl-lang/sqrl)
+  * Smyte Query and Rules Language: a safe, stateful language for event streams
 * [Wikimedia Smite Spam](https://github.com/wikimedia/mediawiki-extensions-SmiteSpam)
   * extension for MediaWiki that helps identify and manage spam content on a wiki
 

--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ Help contribute by opening a pull request to add more resources and tools!
   * high-performance rules engine for real-time event processing at scale, designed for Trust & Safety and anti-abuse work
 * [RulesEngine by Microsoft](https://microsoft.github.io/RulesEngine/)
   * library for abstracting business logic, rules, and policies from a system via JSON  for .NET language families
-* [SQRL](https://github.com/sqrl-lang/sqrl)
-  * Smyte Query and Rules Language: a safe, stateful language for event streams
+* [SQRL (Smyte Query and Rules Language)](https://github.com/sqrl-lang/sqrl)
+  * Safe, stateful language for event streams; project inactive as of 2023
 * [Wikimedia Smite Spam](https://github.com/wikimedia/mediawiki-extensions-SmiteSpam)
   * extension for MediaWiki that helps identify and manage spam content on a wiki
 


### PR DESCRIPTION
SQRL came out of Smyte, the company that was [acquired by Twitter](https://techcrunch.com/2018/06/21/twitter-acquires-anti-abuse-technology-provider-smyte/) in 2018.

The open-source project appears inactive, so I'm not sure if you want to include it here. AFAIK Smyte was much-loved by T&S teams before it shut down. I've seen some T&S vendors demo usage of it, but I don't know whether it's really used much today.